### PR TITLE
Fix resuming of failed downloads + prettier terminal output

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,13 +56,12 @@ def get_image(page: int, chapter_link: str) -> Image:
 
 def download_manga(chapter, chapter_link, title, cur_dir):
     filedir = (cur_dir / f"Manga/{title}/{chapter}")
+
+    pages = determine_page_number(chapter_link)
     try:
         filedir.mkdir(parents=True, exist_ok=False)
     except FileExistsError:
-        print(f"Chapter \"{chapter}\" directory exists, skipping download...")
-        return
-
-    pages = determine_page_number(chapter_link)
+        print(f"Chapter \"{chapter}\" directory exists, skipping if complete...              \r", end="") #spacing to ensure carriage return is cleared out
 
     if pages > 99:
         chapter_length = 3
@@ -72,11 +71,13 @@ def download_manga(chapter, chapter_link, title, cur_dir):
         chapter_length = 1
 
     for page in range(1, pages + 1):
-        image = get_image(page, chapter_link)
-
         file = filedir / f"{page:0{chapter_length}}.jpg"
-        image.save(file)
-        print(f"Completed {page}/{pages} of Chapter {chapter}.")
+        if Path(file).is_file():
+            print(f"Page {page} of Chapter {chapter} already exists, skipping...            \r", end="")
+        else:
+            image = get_image(page, chapter_link)
+            image.save(file)
+            print(f"Completed {page}/{pages} of Chapter {chapter}.                          \r", end="")
     return
 
 

--- a/main.py
+++ b/main.py
@@ -56,8 +56,8 @@ def get_image(page: int, chapter_link: str) -> Image:
 
 def download_manga(chapter, chapter_link, title, cur_dir):
     filedir = (cur_dir / f"Manga/{title}/{chapter}")
-
     pages = determine_page_number(chapter_link)
+    
     try:
         filedir.mkdir(parents=True, exist_ok=False)
     except FileExistsError:


### PR DESCRIPTION
I had my internet drop out a few times while downloading some manga, but once I was finished I realized that some pages had failed to download. Looking into the code, I noticed that the program only checked for the presence of the chapter directory to determine if it should skip, not the actual contents. If it dies in the middle of a chapter, it cannot go back for the remaining pages. This small rewrite checks each page's presence individually to ensure that everything has been downloaded. While I was changing things around, I also added carriage return to the printout of the downloads, so the output of the download itself goes from a wall of text to a single line that updates with each new page.